### PR TITLE
#64 Replace bnd-maven-plugin with maven-bundle-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 		<ri.version>1.3</ri.version>
 		<se.version>1.0.10</se.version>
 		<si.version>${project.version}</si.version><!-- -->
-		<si.quantity.version>1.1</si.quantity.version><!-- To handle quantity separately, 
+		<si.quantity.version>1.1</si.quantity.version><!-- To handle quantity separately,
 			makes deployment easier -->
 		<project.build.javaVersion>${jdkVersion}</project.build.javaVersion>
 		<maven.compile.targetLevel>1.8</maven.compile.targetLevel>
@@ -51,21 +51,14 @@
 						<encoding>${project.build.sourceEncoding}</encoding>
 					</configuration>
 				</plugin>
-				
+
 				<!-- ======================================================= -->
 				<!-- OSGi bundles with BND -->
 				<!-- ======================================================= -->
 				<plugin>
-					<groupId>biz.aQute.bnd</groupId>
-					<artifactId>bnd-maven-plugin</artifactId>
+					<groupId>org.apache.felix</groupId>
+					<artifactId>maven-bundle-plugin</artifactId>
 					<version>4.2.0</version>
-					<executions>
-						<execution>
-							<goals>
-								<goal>bnd-process</goal>
-							</goals>
-						</execution>
-					</executions>
 				</plugin>
 
 				<!-- ======================================================= -->

--- a/units-java8/pom.xml
+++ b/units-java8/pom.xml
@@ -9,6 +9,7 @@
 	</parent>
 	<artifactId>si-units-java8</artifactId>
 	<name>SI Units for Java SE 8</name>
+  <packaging>bundle</packaging>
 
 	<!-- ======================================================= -->
 	<!-- Build Settings -->
@@ -97,9 +98,10 @@
 				<artifactId>maven-source-plugin</artifactId>
 			</plugin>
 
-			<plugin>
-				<groupId>biz.aQute.bnd</groupId>
-				<artifactId>bnd-maven-plugin</artifactId>
+ 			<plugin>
+				<groupId>org.apache.felix</groupId>
+				<artifactId>maven-bundle-plugin</artifactId>
+				<extensions>true</extensions>
 			</plugin>
 
 			<plugin>

--- a/units/pom.xml
+++ b/units/pom.xml
@@ -8,6 +8,7 @@
 	</parent>
 	<artifactId>si-units</artifactId>
 	<name>SI Units</name>
+  <packaging>bundle</packaging>
 
 	<!-- ======================================================= -->
 	<!-- Build Settings -->
@@ -103,11 +104,6 @@
 				<artifactId>maven-source-plugin</artifactId>
 			</plugin>
 
-			<plugin>
-				<groupId>biz.aQute.bnd</groupId>
-				<artifactId>bnd-maven-plugin</artifactId>
-			</plugin>
-
 			<!-- ======================================================= -->
 			<!-- JAR -->
 			<!-- ======================================================= -->
@@ -123,20 +119,12 @@
 			<!-- ======================================================= -->
 			<!-- Packaging (OSGi bundle) -->
 			<!-- ======================================================= -->
-			<!--
 			<plugin>
 				<groupId>org.apache.felix</groupId>
 				<artifactId>maven-bundle-plugin</artifactId>
 				<extensions>true</extensions>
-				<configuration>
-					<instructions>
-						<Export-Package>si.uom</Export-Package>
-						<Private-Package>si.uom.impl</Private-Package>
-					</instructions>
-				</configuration>
 			</plugin>
-			-->
-			
+
 			<!-- ======================================================= -->
 			<!-- JavaDoc Attachment -->
 			<!-- ======================================================= -->


### PR DESCRIPTION
This should fix the OSGI Problem with the missing export package.

Note: I didn't configure the private package, because by default `impl` and `internal` packages won't be exported. See [here](https://felix.apache.org/documentation/subprojects/apache-felix-maven-bundle-plugin-bnd.html#default-behavior).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unitsofmeasurement/si-units/65)
<!-- Reviewable:end -->
